### PR TITLE
V1 query change with improvements with cross-listed sections, getting current terma

### DIFF
--- a/UDP/course_materialized_view.md
+++ b/UDP/course_materialized_view.md
@@ -92,3 +92,15 @@ REFRESH MATERIALIZED view v1_student_current_term_course;
 REFRESH MATERIALIZED view v2_student_current_term_course_assignment_avg;
 REFRESH MATERIALIZED view v3_student_current_term_course_activities;
 ```
+
+## Auto-Refreshed Materialized Views
+Details are here: https://resources.unizin.org/display/UDP/UDP+Context+store
+You can adjust the query at the bottom of the resources page link to verify all views have the right owner attached:
+
+``` select
+  matviewname
+from pg_matviews
+where
+  matviewowner = 'institution'
+  order by matviewname asc;
+  ```

--- a/UDP/course_materialized_view.md
+++ b/UDP/course_materialized_view.md
@@ -10,23 +10,29 @@ and current_timestamp > at2.term_begin_date ),
 courses as 
 (select co.course_offering_id, co.le_code as canvas_course_title, co.available_credits as credits, co.academic_term_id, term_name
 from entity.course_offering co join term_info at2 on co.academic_term_id = at2.academic_term_id where co.le_status = 'available'),
+
 sections as 
 (select cs.course_section_id , cs2.lms_ext_id as canvas_section_id, cs.le_current_course_offering_id as course_offering_id, co4.lms_ext_id as "Canvas_Course_ID", cs.le_name as section_name, cs.section_number as "Section"
 from entity.course_section cs join keymap.course_section cs2 on cs.course_section_id = cs2.id join keymap.course_offering co4 on co4.id = cs.le_current_course_offering_id and cs.status='active'),
 courses_sections_of_current_term as (select c.canvas_course_title, c.term_name, s.*, c.academic_term_id, c.credits from courses c join sections s on c.course_offering_id=s.course_offering_id),
+
 enrollment as 
 (select cse.course_section_id, cse.person_id, REPLACE (lower(pe.email_address), '@umich.edu', '') as uniqname, p."name" as person_name from entity.course_section_enrollment cse join entity.person_email pe 
 on pe.person_id = cse.person_id join entity.person p on p.person_id = cse.person_id where cse."role"='Student' and cse.role_status = 'Enrolled' and cse.enrollment_status = 'Active'),
 courses_enrollment as (select cst.*, e.person_id, e.uniqname, e.person_name from courses_sections_of_current_term cst join enrollment e on e.course_section_id = cst.course_section_id),
 course_grades as (select ce.*, cg.le_current_score as "Current_Grade", cg.le_final_score as "Final_Grade", cg.gpa_cumulative_excluding_course_grade as cumulative_gpa from entity.course_grade cg join courses_enrollment ce on ce.course_section_id = cg.course_section_id and ce.person_id = cg.person_id),
+
 aca_prog_major as (select am.academic_program_id, am.description as academic_major, ap.description as academic_program, ap.educational_level, am.academic_major_id 
 from entity.academic_major am join entity.academic_program ap on ap.academic_program_id = am.academic_program_id),
 person_term_major_academic as (select pamat.academic_major_id, pat.athletic_participant_sport, pat.cen_academic_level , pat.gpa_credits_units_hours, pamat.person_id, pat.academic_term_id  
 from entity.person__academic_term pat join entity.person__academic_major__academic_term pamat 
 on pamat.person_id = pat .person_id and pat.academic_term_id = pamat.academic_term_id and pat.eot_academic_load like '%Time'),
+
 person_full_academic_term_major as (select * from aca_prog_major a join person_term_major_academic b on a.academic_major_id = b.academic_major_id ),
+
 courses_enrollment_major as (select a.*, b.academic_major, b.academic_program,b.educational_level, b.athletic_participant_sport, b.cen_academic_level, b.gpa_credits_units_hours  
 from course_grades a join person_full_academic_term_major b on a.person_id = b.person_id and a.academic_term_id = b.academic_term_id)
+
 select "Canvas_Course_ID", canvas_course_title, course_offering_id, "Section", section_name, credits, gpa_credits_units_hours, cumulative_gpa, 
 "Current_Grade", "Final_Grade",  Uniqname, person_name, person_id, cen_academic_level, academic_major, academic_program,  athletic_participant_sport
 , educational_level, term_name, course_section_id, canvas_section_id from courses_enrollment_major 
@@ -95,12 +101,14 @@ REFRESH MATERIALIZED view v3_student_current_term_course_activities;
 
 ## Auto-Refreshed Materialized Views
 Details are here: https://resources.unizin.org/display/UDP/UDP+Context+store
-You can adjust the query at the bottom of the resources page link to verify all views have the right owner attached:
 
-``` select
-  matviewname
-from pg_matviews
-where
-  matviewowner = 'institution'
-  order by matviewname asc;
-  ```
+## Athletic student google sheet roster
+Athletic dept provides all the student enrolled to their program in current term via a google sheet. We have an additional step 
+in making this data available to Tableau dashboard as table called `student_athletic_export`. We created this table since Tableau
+has some issues connecting to google sheets.
+Every term this table (student_athletic_export) need to updated with latest data. This table resides in the context store with user account provisioned for the project
+Steps to update the table
+1. create a CSV File from the current term student roster
+2. Open the SQL editor from you SQL client and run `delete from student_athlete_export ` to delete all the rows
+3. Right click on the `student_athletic_export` table import CSV (from step 1)
+4. Verify it has latest info.

--- a/UDP/course_materialized_view.md
+++ b/UDP/course_materialized_view.md
@@ -61,7 +61,7 @@ select lar.person_id,
 la.course_offering_id, 
 la.learner_activity_id,
 la.title as assignment_title,
-TO_CHAR(la.due_date at time zone 'UTC' at time zone 'EST', 'YYYY-MM-DD HH12:MI AM')  as assignment_due_date,
+TO_CHAR(la.due_date at time zone 'UTC' at time zone 'EST', 'YYYY-MM-DD HH24:MI:SS')  as assignment_due_date,
 CASE
    WHEN lar.gradebook_status = 'true' and lar.grading_status = 'graded' THEN lar.published_score
    ELSE null

--- a/UDP/course_materialized_view.md
+++ b/UDP/course_materialized_view.md
@@ -4,62 +4,30 @@
 ```
 DROP MATERIALIZED view v1_student_current_term_course;
 create materialized view v1_student_current_term_course as
- select
-	co2.lms_ext_id as "Canvas_Course_ID",
-	co.le_code as canvas_course_title,
-	co.course_offering_id as course_offering_id,
-	cs.section_number as "Section",
-	co.available_credits as Credits,
-    pat.gpa_credits_units_hours,
-	cg2.gpa_cumulative_excluding_course_grade as cumulative_gpa,
-	-- regexp_replace(co.syllabus_content,'\s*(<[^>]+>|<script.+?<\/script>|<style.+?<\/style>)\s*','','gi') as syllabus, 
-	--regexp_replace(co.syllabus_content, '\s*(<[^>]+>|<script.+?<\/script>|<style.+?<\/style>)\s*','','gi') as syllabus,
-	cg.le_current_score as "Current_Grade", 
-	cg.le_final_score as "Final_Grade",
-    REPLACE (lower(pe.email_address), '@umich.edu', '') as Uniqname,
-    pe.person_id as person_id,
-    pat.cen_academic_level, 
-    am.academic_program_id, 
-    am.description as academic_major,
-    pat.athletic_participant_sport, 
-	ap.description as academic_program,
-	ap.educational_level
-from 
-entity.person_email pe, 
-entity.course_section_enrollment cse,
-entity.course_section cs,
-entity.course_offering co,
-entity.academic_term at2,
-entity.course_grade cg,
-keymap.course_offering co2,
-entity.course_grade cg2,
-entity.person__academic_term pat, 
-entity.person__academic_major__academic_term pamat,
-entity.academic_major am,
-entity.academic_program ap
-where 
-pe.person_id = cse.person_id
-and cse.role_status = 'Enrolled'
-and cse."role" = 'Student'
-and cs.course_section_id = cse.course_section_id
-and co.course_offering_id = cs.course_offering_id
-and co.academic_term_id = at2.academic_term_id 
-and cg.course_section_id = cs.course_section_id
-and cg.person_id = cse.person_id
-and co.le_status = 'available'
-and co2.id = co.course_offering_id
-and cg2.course_section_id = cs.course_section_id 
-and cg2.person_id = pe.person_id
-and pat.academic_term_id = at2.academic_term_id
-and at2.academic_term_id = pamat.academic_term_id
-and pe.person_id = pat.person_id 
-and pat.person_id = pamat.person_id 
-and pamat.academic_major_id = am.academic_major_id
-and am.academic_program_id = ap.academic_program_id
--- get current term data
-and current_timestamp < at2.term_end_date
-and current_timestamp > at2.term_begin_date 
-order by pe.person_id 
+ with
+courses as 
+(select co.course_offering_id, co.le_code as canvas_course_title, co.available_credits as credits, co.academic_term_id from entity.course_offering co ),
+sections as 
+(select cs.course_section_id , cs2.lms_ext_id as canvas_section_id, cs.le_current_course_offering_id as course_offering_id, co4.lms_ext_id as "Canvas_Course_ID", cs.le_name as section_name, cs.section_number as "Section"
+from entity.course_section cs join keymap.course_section cs2 on cs.course_section_id = cs2.id join keymap.course_offering co4 on co4.id = cs.le_current_course_offering_id and cs.status='active'),
+term_info as (select at3.academic_term_id, at3."name" as term_name from entity.academic_term at3 join keymap.academic_term at4 on at3.academic_term_id=at4.id and current_date < at3.le_term_end_date and at3.le_term_begin_date > current_date ),
+courses_sections_of_current_term as (select c.canvas_course_title, s.*, c.academic_term_id, t.term_name, Credits from courses c join sections s on c.course_offering_id=s.course_offering_id join term_info t on t.academic_term_id = c.academic_term_id),
+enrollment as 
+(select cse.course_section_id, cse.person_id, REPLACE (lower(pe.email_address), '@umich.edu', '') as uniqname, p."name" as person_name from entity.course_section_enrollment cse join entity.person_email pe 
+on pe.person_id = cse.person_id join entity.person p on p.person_id = cse.person_id where cse."role"='Student' and cse.role_status = 'Enrolled' and cse.enrollment_status = 'Active'),
+courses_enrollment as (select cst.*, e.person_id, e.uniqname, e.person_name from courses_sections_of_current_term cst join enrollment e on e.course_section_id = cst.course_section_id),
+course_grades as (select ce.*, cg.le_current_score as "Current_Grade", cg.le_final_score as "Final_Grade", cg.gpa_cumulative_excluding_course_grade as cumulative_gpa from entity.course_grade cg join courses_enrollment ce on ce.course_section_id = cg.course_section_id and ce.person_id = cg.person_id),
+aca_prog_major as (select am.academic_program_id, am.description as academic_major, ap.description as academic_program, ap.educational_level, am.academic_major_id 
+from entity.academic_major am join entity.academic_program ap on ap.academic_program_id = am.academic_program_id),
+person_term_major_academic as (select pamat.academic_major_id, pat.athletic_participant_sport, pat.cen_academic_level , pat.gpa_credits_units_hours, pamat.person_id, pat.academic_term_id  
+from entity.person__academic_term pat join entity.person__academic_major__academic_term pamat 
+on pamat.person_id = pat .person_id and pat.academic_term_id = pamat.academic_term_id and pat.eot_academic_load like '%Time'),
+person_full_academic_term_major as (select * from aca_prog_major a join person_term_major_academic b on a.academic_major_id = b.academic_major_id ),
+courses_enrollment_major as (select a.*, b.academic_major, b.academic_program,b.educational_level, b.athletic_participant_sport, b.cen_academic_level, b.gpa_credits_units_hours  
+from course_grades a join person_full_academic_term_major b on a.person_id = b.person_id and a.academic_term_id = b.academic_term_id)
+select "Canvas_Course_ID", canvas_course_title, course_offering_id, "Section", section_name, credits, gpa_credits_units_hours, cumulative_gpa, 
+"Current_Grade", "Final_Grade",  Uniqname, person_name, person_id, cen_academic_level, academic_major, academic_program,  athletic_participant_sport
+, educational_level, term_name, course_section_id, canvas_section_id from courses_enrollment_major 
 with data
 ```
 


### PR DESCRIPTION
1. This should now get all cross-listed sections in a course  taking the `le_current_course_offering_id` as the course_offerning_id 
2. Only getting person_academic_term major with some credit time like `NoCreditTime`, HalfCreditTime` Etc

Execution Time:
V1_query: 2min
v2_query: 14min
v3_query: 4min

