### PR TITLE
Adding first and last name to v1 query

### DIFF
--- a/UDP/current_term_courses/v1_student_current_term_course.sql
+++ b/UDP/current_term_courses/v1_student_current_term_course.sql
@@ -1,6 +1,3 @@
-DROP MATERIALIZED view v1_student_current_term_course;
-
-create materialized view v1_student_current_term_course AS
 WITH
  term_info AS (
  SELECT
@@ -64,6 +61,12 @@ SELECT
   csct.*,
   cse.person_id, 
   p.name AS person_name, 
+  case
+  when p.first_name is null then REGEXP_EXTRACT(p.name, r'^\w+(?:-\w+)?') else p.first_name
+  end first_name,
+  case 
+  when p.last_name is null then REGEXP_EXTRACT(p.name, r'\w+(?:-\w+)?$') else p.last_name
+  end last_name,
   REPLACE (LOWER(pe.email_address), '@umich.edu', '') AS uniqname 
 FROM 
   courses_sections_of_current_term csct 
@@ -182,6 +185,8 @@ SELECT
  avg_course_grade,
  uniqname,
  person_name,
+ first_name,
+ last_name,
  person_id,
  cen_academic_level,
  academic_major,
@@ -193,4 +198,3 @@ SELECT
  canvas_section_id
 FROM
  courses_enrollment_major
-with data

--- a/UDP/current_term_courses/v1_student_current_term_course.sql
+++ b/UDP/current_term_courses/v1_student_current_term_course.sql
@@ -61,11 +61,9 @@ SELECT
   csct.*,
   cse.person_id, 
   p.name AS person_name, 
-  case
-  when p.first_name is null then REGEXP_EXTRACT(p.name, r'^\w+(?:-\w+)?') else p.first_name
+  case when p.first_name is null then REGEXP_EXTRACT(p.name, r'^\w+(?:-\w+)?') else p.first_name
   end first_name,
-  case 
-  when p.last_name is null then REGEXP_EXTRACT(p.name, r'\w+(?:-\w+)?$') else p.last_name
+  case when p.last_name is null then REGEXP_EXTRACT(p.name, r'\w+(?:-\w+)?$') else p.last_name
   end last_name,
   REPLACE (LOWER(pe.email_address), '@umich.edu', '') AS uniqname 
 FROM 

--- a/UDP/current_term_courses/v2_student_current_term_course_assignment_avg.sql
+++ b/UDP/current_term_courses/v2_student_current_term_course_assignment_avg.sql
@@ -1,6 +1,3 @@
-DROP MATERIALIZED view v2_student_current_term_course_assignment_avg;
-
-create materialized view v2_student_current_term_course_assignment_avg as
 WITH
  lar AS (
  SELECT
@@ -35,4 +32,3 @@ WHERE
 GROUP BY
  la.course_offering_id,
  lar.learner_activity_id
-with data

--- a/UDP/current_term_courses/v3_student_current_term_course_activities.sql
+++ b/UDP/current_term_courses/v3_student_current_term_course_activities.sql
@@ -1,6 +1,3 @@
-DROP MATERIALIZED view v3_student_current_term_course_activities;
-
-create materialized view v3_student_current_term_course_activities as
 SELECT
  lar.person_id,
  la.course_offering_id,
@@ -48,4 +45,3 @@ ON
  lar.learner_activity_result_id = a.learner_activity_result_id
 WHERE
  la.status = 'published'
-with data


### PR DESCRIPTION
Fixes #8 
Adding First name and last name to the v1 query as per requirement by ACUME. IN some cases UDP has first name and last name as null, in that case we are slitting the it based on `name`

RUN this as is in the BQ console and you should see the desired results. 
```
select 'tayler-swift song last-name' as name, 
REGEXP_EXTRACT('tayler-swift song last-name', r'^\w+(?:-\w+)?') as first_name,
REGEXP_EXTRACT('tayler-swift song last-name', r'\w+(?:-\w+)?$') as  last_name
```
Some real UDP data to test, run this in the BQ console and see the results

```
select person_id, name, first_name, last_name from 
`context_store_entity.person` where person_id in (682283, 785880, 650608, 438599, 524943)
```

```
select a.person_id, a.name, 
 case
 when a.first_name is null then REGEXP_EXTRACT(a.name, r'^\w+(?:-\w+)?') else a.first_name
 end first_name,
 case 
 when a.last_name is null then REGEXP_EXTRACT(a.name, r'\w+(?:-\w+)?$') else a.last_name
 end last_name,
 from `context_store_entity.person` a 
where a.person_id in (682283, 785880, 650608, 438599, 524943)
```

I have removed materialized view syntax since it is not relevant anymore after moved to Biqquery Scheduled query approach. Only changes are in v1 query and v2/v3 is just removal  materialized view syntax