### PR TITLE
fix LTI course list query

### DIFF
--- a/UDW/LTI_tool.md
+++ b/UDW/LTI_tool.md
@@ -68,7 +68,7 @@ order by etd.canvas_id desc, cd2.canvas_id ASC, ud."name" ASC
 ## List courses (course name, course id, term) with the LTI tool installed
 
 ```sql
-SELECT DISTINCT
+SELECT
   cd.name AS course_name,
   cd.canvas_id AS course_id,
   cd.enrollment_term_id AS course_term_id,


### PR DESCRIPTION
This PR corrects mistakes and problems I found in the LTI course list query.

When I was trying to use the query to search for MWrite Peer Review tool installations in Canvas, I needed to change the query a little.  I found the nested queries to be confusing, so I cleaned it up to make it easier to understand.

* Added qualifiers to all column names so it became clear to which tables they belong.
* Unnested the queries to make a join, which makes the query shorter and easier to understand.  In a more complex query, this is likely to be more efficient, too.
* As a result of the above two changes, I found that the original query was using the `cunif.course_ui_navigation_item_id = cunid.id` condition **_TWICE_**.
* Added `lower()` function call around the tool name string to make it easier to paste in a tool name without editing the case of its letters.
* Added tool ID to the output.
* Fixed formatting and enabled GFM SQL highlighting.