### PR TITLE
Calculating the term end date based on RO recommendation

### DIFF
--- a/UDP/current_term_courses/v1_student_current_term_course.sql
+++ b/UDP/current_term_courses/v1_student_current_term_course.sql
@@ -6,7 +6,7 @@ WITH
  FROM
    `udp-umich-prod.context_store_entity.academic_term` at2
  WHERE
-   DATE(current_timestamp) < DATE_ADD(at2.term_end_date, INTERVAL 2 WEEK)
+   DATE(current_timestamp) <= DATE_ADD(at2.term_end_date, 10 DAY)
    AND DATE(current_timestamp) >= at2.term_begin_date ),
  courses AS (
  SELECT

--- a/UDP/current_term_courses/v1_student_current_term_course.sql
+++ b/UDP/current_term_courses/v1_student_current_term_course.sql
@@ -6,7 +6,7 @@ WITH
  FROM
    `udp-umich-prod.context_store_entity.academic_term` at2
  WHERE
-   DATE(current_timestamp) <= DATE_ADD(at2.term_end_date, 10 DAY)
+   DATE(current_timestamp) <= DATE_ADD(at2.term_end_date, INTERVAL 10 DAY)
    AND DATE(current_timestamp) >= at2.term_begin_date ),
  courses AS (
  SELECT


### PR DESCRIPTION
Fixes #24 

Uses this query to see what term_End + 10_days looks like


```
SELECT
  academic_term_id,
  name AS term_name,
  at2.term_begin_date,
  at2.term_end_date,
  DATE_ADD(at2.term_end_date, INTERVAL 10 DAY) AS ten_days,
FROM
  `udp-umich-prod.context_store_entity.academic_term` at2
```

Playaround b/w terms date by changing the `my_date` to see which term is picked in a future data. (Make sure the below query is what you will have when running from BQ console), you need click `View Results` to see the data

```
DECLARE my_date DATE DEFAULT '2024-07-04';
SELECT
  academic_term_id,
  name AS term_name,
  at2.term_begin_date,
  at2.term_end_date,
  DATE_ADD(at2.term_end_date, INTERVAL 10 DAY) AS ten_days,
FROM
  `udp-umich-prod.context_store_entity.academic_term` at2
WHERE
  at2.term_year = 2024
  AND my_date <= DATE_ADD(at2.term_end_date, INTERVAL 10 DAY)
  AND my_date >= at2.term_begin_date
ORDER BY
  academic_term_id
```